### PR TITLE
Display optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.json
 visualization/20*
 *.log
+visualization/*.sh
 *.err
-*.sh
 *.list
 __pycache__

--- a/perf/scripts/collate_json.py
+++ b/perf/scripts/collate_json.py
@@ -1,0 +1,58 @@
+import json
+import sys
+import os
+import re
+import datetime
+
+# list of test types
+gen_files = [ "speed_kem", "speed_sig", "speed", "handshakes" ]
+
+if len(sys.argv)!=4:
+   print("Usage: %s <startdate> <datafile-folder> <output-folder>" % (sys.argv[0]))
+   exit(-1)
+
+# Parse start date (param1)
+sd = datetime.datetime.strptime(sys.argv[1], '%Y-%m-%d')
+
+# Ensure param2 is directory name:
+datadir = os.fsencode(sys.argv[2])
+    
+outdir = sys.argv[3]
+
+tt = {}
+    
+# prepare multi-date JSON structures for each test type
+for i in gen_files:
+   tt[i]={}
+
+# collect all files after start date
+for file in os.listdir(datadir):
+     filename = os.fsdecode(file)
+     if filename.endswith(".tgz"): 
+         dt = datetime.datetime.strptime(filename[0:10], '%Y-%m-%d')
+         if (dt >= sd): 
+            d = dt.strftime("%Y-%m-%d")
+            # extract to temporary folder
+            os.system("rm -rf tmp && mkdir tmp && cd tmp && tar xzvf "+os.path.join(sys.argv[2], filename))
+            # read files populating JSON structure for this date
+            for t in gen_files:
+               print("Loading %s.json" % (t))
+               with open(os.path.join("tmp", "results", t+".json")) as jf:
+                  tt[t][d]=json.load(jf) 
+               # if -ref files exist, run the merge logic:
+               with open(os.path.join("tmp", "results", t+"-ref.json")) as jf:
+                  # get data
+                  print("Adding in %s-ref.json:" % (t))
+                  refs=json.load(jf) 
+                  # iterate over all algorithms, adding a -ref variant
+                  nd = {}
+                  for key in tt[t][d].keys():
+                     if key in refs.keys():
+                        print("  mixing in %s-ref" % (key))
+                        nd[key+"-ref"]=refs[key]
+                     nd[key]=tt[t][d][key]
+                  tt[t][d]=nd
+for i in gen_files:
+   with open(os.path.join(outdir, i+".json"), 'w') as outfile:
+      json.dump(tt[i], outfile)
+

--- a/perf/scripts/gen_website2.sh
+++ b/perf/scripts/gen_website2.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+
+rm -rf tmp && mkdir tmp
+cd tmp && git clone https://github.com/open-quantum-safe/speed.git && cd ..
+rm -rf out && mkdir out && mkdir out/latest
+python3 collate_json.py 2020-10-10 ${1} out/latest
+cp tmp/speed/visualization/*.html out
+cp tmp/speed/visualization/*.js out
+cp tmp/speed/visualization/*.css out
+cd out && tar czvf ../site2.tgz * && cd ..
+cp site2.tgz ${1}/site
+rm -rf tmp out
+

--- a/perf/scripts/mount_s3.sh
+++ b/perf/scripts/mount_s3.sh
@@ -23,5 +23,9 @@ else
    chmod 600 ~/.passwd-s3fs
    mkdir -p ${LOCALBUCKETPATH}
    s3fs ${BUCKETNAME} ${LOCALBUCKETPATH}
-   echo "$BUCKETNAME mounted"
+   if [ $? -eq 0 ]; then
+      echo "$BUCKETNAME mounted"
+   else
+      echo "Mount failed"
+   fi
 fi

--- a/perf/scripts/run-tests.sh
+++ b/perf/scripts/run-tests.sh
@@ -44,7 +44,7 @@ if [ $? -eq 0 ]; then
     echo "Copy test results to S3"
     today=`date +%Y-%m-%d-%H_%M_%S`
     tar czvf ${S3FOLDER}/${today}.tgz results/*.json
-    ./gen_website.sh ${S3FOLDER}
+    ./gen_website2.sh ${S3FOLDER}
     echo "Copy complete: ${S3FOLDER}/${today}.tgz"
 else
     echo "Couldn't mount S3 bucket. Not copying out test results."

--- a/visualization/handshakes_s3.html
+++ b/visualization/handshakes_s3.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Handshake performance</title>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script> 
+    <link rel="stylesheet" type="text/css" href="oqs-style.css">
+  </head>
+  <body>
+    <div class="wrapper">
+      <h1>TLS handshake performance</h1>
+      <h2>Handshakes per second per algorithm</h2>
+    <script src="oqs_utils.js"></script>
+     <h3>Select signature algorithm and minimum values (set to include/exclude algorithms)</h3>
+     <form id="filterForm" name="filterForm" onsubmit="SubmitHandshakesForm(event);">
+    <input type="hidden" id="datafile" name="datafile" value="latest/handshakes.json">
+    <label for="shakemin">Handshakes/s:</label>
+    <input type="number" id="shakemin" name="shakemin" maxlength="4" size="4">
+       <label for="familyselector">Algorithm family:</label>
+       <select id="familyselector" name="familyselector" multiple onchange="SubmitHandshakesForm(event)">
+       <option selected>All</option>
+       <option>BIKE</option>
+       <option>Frodo</option>
+       <option>HQC</option>
+       <option>Kyber</option>
+       <option>McEliece</option>
+       <option>NTRU</option>
+       <option>Saber</option>
+       <option>SIDH</option>
+       <option>Sike</option>
+       </select>
+    <label for="sigalg">Signature Algorithm:</label>
+  <select id="sigalg" name="sigalg" onchange="SubmitHandshakesForm(event)">
+  <!-- add a single option to have something; will be replaced by JSON contents at first file read-->
+    <option>dilithium3</option>
+  </select>
+       <label for="nistlevel">NIST level:</label>
+       <select id="nistlevel" name="nistlevel" onchange="SubmitHandshakesForm(event)">
+       <option>All</option>
+       <option>Level 1</option>
+       <option>Level 3</option>
+       <option>Level 5</option>
+       </select>
+       <label for="date">Date(s):</label>
+       <select id="date" name="date" onchange="SubmitHandshakesForm(event)">
+       <option>All</option>
+
+    <input type="submit" value="Filter">
+</form>
+     <h3>KEM algorithms & performance values (click name to enable/disable)</h3>
+
+
+
+     <table id="downloadtable" name="downloadtable"></table>
+     <table id="numberstable" name="numberstable"></table>
+<canvas id="handshakesChart" width="1600" height="900"></canvas>
+
+
+    <script src="handshakes_script.js"></script>
+    </div>
+   <hr>
+   Color-coding derived from <a href="https://csrc.nist.gov/CSRC/media/Presentations/the-2nd-round-of-the-nist-pqc-standardization-proc/images-media/moody-opening-remarks.pdf#page=15" target=_new>a NIST presentation</a>.
+
+
+  </body>
+</html>

--- a/visualization/handshakes_script.js
+++ b/visualization/handshakes_script.js
@@ -58,9 +58,7 @@ function LoadData(fullInit) {
     var charttype = "bar";
 
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false,
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
        // also populate sigalgs array just once
        // remove initial default option
        sigalgOption.remove(0); 

--- a/visualization/openssl_speed_s3.html
+++ b/visualization/openssl_speed_s3.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>OpenSSL speed</title>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script> 
+    <link rel="stylesheet" type="text/css" href="oqs-style.css">
+  </head>
+  <body>
+   <div class="wrapper">
+      <h1>OpenSSL speed</h1>
+      Operations per second per algorithm
+    <script src="oqs_utils.js"></script>
+     <h3>Set minimum values (set to include/exclude algorithms)</h3>
+     <form id="filterForm" name="myForm" onsubmit="SubmitOSSLspeedForm(event);">
+       <input type="hidden" id="datafile" name="datafile" value="latest/speed.json">
+       <label for="keygenmin">Keygen/s:</label>
+       <input type="number" id="keygenmin" name="keygenmin" maxlength="4" size="4">
+       <label for="encapmin">Encap/s:</label>
+       <input type="number" id="encapmin" name="encapmin" maxlength="4" size="4">
+       <label for="decapmin">Decap/s:</label>
+       <input type="number" id="decapmin" name="decapmin" maxlength="4" size="4">
+       <label for="signmin">Sign/s:</label>
+       <input type="number" id="signmin" name="signmin" maxlength="4" size="4">
+       <label for="decapmin">Verify/s:</label>
+       <input type="number" id="verifymin" name="verifymin" maxlength="4" size="4">
+       <select id="oqsalg" name="oqsalg" onchange="SubmitOSSLspeedForm(event)">
+       <option>All</option>
+       <option>OQS only</option>
+       </select>
+       <label for="familyselector">Algorithm family:</label>
+       <select id="familyselector" name="familyselector" multiple onchange="SubmitOSSLspeedForm(event)">
+       <option selected>All</option>
+       <option>BIKE</option>
+       <option>Frodo</option>
+       <option>HQC</option>
+       <option>Kyber</option>
+       <option>McEliece</option>
+       <option>NTRU</option>
+       <option>Saber</option>
+       <option>SIDH</option>
+       <option>Sike</option>
+       <option>Falcon</option>
+       <option>Dilithium</option>
+       <option>SPHINCS</option>
+       <option>Rainbow</option>
+       <option>Picnic</option>
+       </select>
+       <label for="refselector">Reference code:</label>
+       <select id="refselector" name="refselector" onchange="SubmitOSSLspeedForm(event)">
+       <option selected>All</option>
+       <option>Ref only</option>
+       <option>Optimized only</option>
+       </select>
+       <label for="nistlevel">NIST level:</label>
+       <select id="nistlevel" name="nistlevel" onchange="SubmitOSSLspeedForm(event)">
+       <option>All</option>
+       <option>Level 1</option>
+       <option>Level 3</option>
+       <option>Level 5</option>
+       </select>
+       <label for="date">Date(s):</label>
+       <select id="date" name="date" onchange="SubmitOSSLspeedForm(event)">
+       <option>All</option>
+       <input type="submit" value="Filter">
+     </form>
+
+     <table id="downloadtable" name="downloadtable"></table>
+     <table id="numberstable" name="numberstable"></table>
+
+     <h3>Keygen/s (click algorithm name to enable/disable)</h3>
+       <canvas id="keygenChart" width="1200" height="700"></canvas>
+     <h3>Encap/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="encapChart" width="1600" height="900"></canvas>
+     <h3>Decap/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="decapChart" width="1600" height="900"></canvas>
+     <h3>Sign/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="signChart" width="1600" height="900"></canvas>
+     <h3>Verify/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="verifyChart" width="1600" height="900"></canvas>
+
+     <h3>Configuration information</h3>
+       <table id="configtable" name="configtable">
+          <tr>Data collected via AWS cron using image "openquantumsafe/oqs-perf"</tr>
+       </table>
+
+    <script src="openssl_speed_script.js"></script>
+   </div>
+   <hr>
+   Color-coding derived from <a href="https://csrc.nist.gov/CSRC/media/Presentations/the-2nd-round-of-the-nist-pqc-standardization-proc/images-media/moody-opening-remarks.pdf#page=15" target=_new>a NIST presentation</a>.
+
+  </body>
+</html>

--- a/visualization/openssl_speed_script.js
+++ b/visualization/openssl_speed_script.js
@@ -56,9 +56,7 @@ function LoadData(fullInit) {
     var charttype = "bar";
 
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false,
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
     }
 
     var setDate = formData.get("date");

--- a/visualization/performance_s3.html
+++ b/visualization/performance_s3.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>OQS performance</title>
+    <link rel="stylesheet" type="text/css" href="oqs-style.css">
+  </head>
+  <body>
+      <h1>OQS algorithm performance visualizations</h1>
+      These pages are previews of OQS performance visualizations of measurements taken by the <a href="https://github.com/open-quantum-safe/speed">OQS speed</a> project.
+
+      <ol>
+	      <li><a href="speed_kem_s3.html">KEM algorithms timeseries</a> (liboqs speed_kem)
+	      <li><a href="speed_sig_s3.html">SIG algorithms timeseries</a> (liboqs speed_sig)
+	      <li><a href="openssl_speed_s3.html">KEM/SIG algorithms</a> (openssl speed)
+	      <li><a href="handshakes_s3.html">TLS handshakes</a> (openssl s_time)
+      </ol>
+      Measurements have been taken on an AWS c4 instance with O3 compile optimizations. Algorithms labelled <i>-ref</i> are reference (C-code only) implementations compiled without special CPU feature support. Algorithms without this moniker are compiled with all CPU extensions available to achieve best performance figures. <br>These graphs will be extended over time to other CPU (types) and cloud infrastructures.
+  </body>
+</html>

--- a/visualization/speed_kem_s3.html
+++ b/visualization/speed_kem_s3.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>KEM performance</title>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script> 
+    <link rel="stylesheet" type="text/css" href="oqs-style.css">
+  </head>
+  <body>
+   <div class="wrapper">
+      <h1>KEM performance</h1>
+      Operations per second per algorithm
+    <script src="oqs_utils.js"></script>
+
+     <h3>Set minimum values (set to include/exclude algorithms)</h3>
+     <form id="filterForm" name="filterForm" onsubmit="SubmitKEMForm(event);">
+       <input type="hidden" id="datafile" name="datafile" value="latest/speed_kem.json">
+       <label for="keygenmin">Keygen/s:</label>
+       <input type="number" id="keygenmin" name="keygenmin" maxlength="4" size="4">
+       <label for="encapmin">Encap/s:</label>
+       <input type="number" id="encapmin" name="encapmin" maxlength="4" size="4">
+       <label for="decapmin">Decap/s:</label>
+       <input type="number" id="decapmin" name="decapmin" maxlength="4" size="4">
+       <label for="familyselector">Algorithm family:</label>
+       <select id="familyselector" name="familyselector" multiple onchange="SubmitKEMForm(event)">
+       <option selected>All</option>
+       <option>BIKE</option>
+       <option>Frodo</option>
+       <option>HQC</option>
+       <option>Kyber</option>
+       <option>McEliece</option>
+       <option>NTRU</option>
+       <option>Saber</option>
+       <option>SIDH</option>
+       <option>Sike</option>
+       </select>
+       <label for="refselector">Reference code:</label>
+       <select id="refselector" name="refselector" onchange="SubmitKEMForm(event)">
+       <option selected>All</option>
+       <option>Ref only</option>
+       <option>Optimized only</option>
+       </select>
+       <label for="nistlevel">NIST level:</label>
+       <select id="nistlevel" name="nistlevel" onchange="SubmitKEMForm(event)">
+       <option>All</option>
+       <option>Level 1</option>
+       <option>Level 3</option>
+       <option>Level 5</option>
+       </select>
+       <label for="date">Date(s):</label>
+       <select id="date" name="date" onchange="SubmitKEMForm(event)">
+       <option>All</option>
+       </select>
+
+       <input type="submit" value="Filter">
+     </form>
+
+     <table id="downloadtable" name="downloadtable"></table>
+     <table id="numberstable" name="numberstable"></table>
+     <h3>Keygen/s (click algorithm name to enable/disable)</h3>
+       <canvas id="keygenChart" width="1200" height="700"></canvas>
+     <h3>Encap/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="encapChart" width="1600" height="900"></canvas>
+     <h3>Decap/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="decapChart" width="1600" height="900"></canvas>
+     <h3>Configuration information</h3>
+       <table id="configtable" name="configtable">
+          <tr>Data collected via AWS cron using image "openquantumsafe/oqs-perf"</tr>
+       </table>
+   </div>
+    <script src="speed_kem_script.js"></script>
+   <hr>
+   Color-coding derived from <a href="https://csrc.nist.gov/CSRC/media/Presentations/the-2nd-round-of-the-nist-pqc-standardization-proc/images-media/moody-opening-remarks.pdf#page=15" target=_new>a NIST presentation</a>.
+
+  </body>
+</html>

--- a/visualization/speed_kem_script.js
+++ b/visualization/speed_kem_script.js
@@ -75,9 +75,7 @@ function LoadData(fullInit) {
     var charttype = "bar";
 
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, 
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false,  undefined)
     }
 
     // obtain this only now as loadJSONArray could have changed it:

--- a/visualization/speed_sig_s3.html
+++ b/visualization/speed_sig_s3.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>SIG performance</title>
+     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script> 
+    <link rel="stylesheet" type="text/css" href="oqs-style.css">
+  </head>
+  <body>
+   <div class="wrapper">
+      <h1>SIG performance</h1>
+      Operations per second per algorithm
+    <script src="oqs_utils.js"></script>
+
+     <h3>Set minimum values (set to include/exclude algorithms)</h3>
+     <form id="filterForm" name="filterForm" onsubmit="SubmitSIGForm(event);">
+       <input type="hidden" id="datafile" name="datafile" value="latest/speed_sig.json">
+       <label for="keygenmin">Keygen/s:</label>
+       <input type="number" id="keygenmin" name="keygenmin" maxlength="4" size="4">
+       <label for="signmin">Sign/s:</label>
+       <input type="number" id="signmin" name="signmin" maxlength="4" size="4">
+       <label for="verifymin">Verify/s:</label>
+       <input type="number" id="verifymin" name="verifymin" maxlength="4" size="4">
+       <label for="familyselector">Algorithm family:</label>
+       <select id="familyselector" name="familyselector" multiple onchange="SubmitSIGForm(event)">
+       <option selected>All</option>
+       <option>Falcon</option>
+       <option>Dilithium</option>
+       <option>SPHINCS</option>
+       <option>Rainbow</option>
+       <option>Picnic</option>
+       </select>
+       <label for="refselector">Reference code:</label>
+       <select id="refselector" name="refselector" onchange="SubmitSIGForm(event)">
+       <option selected>All</option>
+       <option>Ref only</option>
+       <option>Optimized only</option>
+       </select>
+       <label for="nistlevel">NIST level:</label>
+       <select id="nistlevel" name="nistlevel" onchange="SubmitSIGForm(event)">
+       <option>All</option>
+       <option>Level 1</option>
+       <option>Level 3</option>
+       <option>Level 5</option>
+       </select>
+       <label for="date">Date(s):</label>
+       <select id="date" name="date" onchange="SubmitSIGForm(event)">
+       <option>All</option>
+       </select>
+
+       <input type="submit" value="Filter">
+     </form>
+
+     <table id="downloadtable" name="downloadtable"></table>
+     <table id="numberstable" name="numberstable"></table>
+     <h3>Keygen/s (click algorithm name to enable/disable)</h3>
+       <canvas id="keygenChart" width="1200" height="700"></canvas>
+     <h3>Sign/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="signChart" width="1600" height="900"></canvas>
+     <h3>Verify/s & values (click algorithm name to enable/disable)</h3>
+       <canvas id="verifyChart" width="1600" height="900"></canvas>
+     <h3>Configuration information</h3>
+       <table id="configtable" name="configtable">
+          <tr>Data collected via AWS cron using image "openquantumsafe/oqs-perf"</tr>
+       </table>
+   </div>
+    <script src="speed_sig_script.js"></script>
+   <hr>
+   Color-coding derived from <a href="https://csrc.nist.gov/CSRC/media/Presentations/the-2nd-round-of-the-nist-pqc-standardization-proc/images-media/moody-opening-remarks.pdf#page=15" target=_new>a NIST presentation</a>.
+
+  </body>
+</html>

--- a/visualization/speed_sig_script.js
+++ b/visualization/speed_sig_script.js
@@ -75,9 +75,7 @@ function LoadData(fullInit) {
     var charttype = "bar";
 
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, 
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
     }
 
     // obtain this only now as loadJSONArray could have changed it:


### PR DESCRIPTION
This combines all recent (parameterized) measurements into combined .JSON files: Download is much faster (only 1 HTML, 1 JavaScript and 1 JSON file needed per test, not 1 per day plus a meta-file) so that information is not lost. This is available for testing at https://test.openquantumsafe.org/v2/performance_s3.html as well as http://oqs-tests.s3-website.us-east-2.amazonaws.com/site/ . The latter shows we opened the test results for download straight from AWS. If we'd be able to set up proper CORS handling we could serve the HTML from www.openquantumsafe.org and the current test data from aws. Until then, this PR also generates a `site2.tgz` containing this logic and all data so the whole bundle can still be downloaded to a single site to avoid cross origin hassles.
Particularly @dstebila @xvzcf please let me know what you think. The PR can also be streamlined if we scrap the old way of generating HTML/JS/JSON and only use this going forward.