### PR TITLE
async data retrieval

### DIFF
--- a/visualization/handshakes_script.js
+++ b/visualization/handshakes_script.js
@@ -42,13 +42,19 @@ function fillNumberTable(tabledata, setDate) {
    }
 }
 
+function CleanSlate() {
+       handshakesChart.destroy();
+       handshakesChart=undefined;
+}
+
 // main chart-generator function
 // only populate config data if fullInit set to true
-function LoadData(fullInit) {
+function LoadData(fullInit, cleanSlate) {
     var filterForm = document.getElementById('filterForm');
     var sigalgOption = document.getElementById('sigalg');
     var formData = new FormData(filterForm);
     var sigalg = formData.get("sigalg");
+    if (cleanSlate) CleanSlate();
     if (sigalg==null) {
       console.log("Could not determine signature algorithm. Setting default.");
       sigalg="dilithium3"
@@ -58,10 +64,13 @@ function LoadData(fullInit) {
     var charttype = "bar";
 
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false,
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
-       // also populate sigalgs array just once
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
+    }
+
+    if (refobj == undefined) return; // no data yes
+
+    if (sigalgs.length == 0) {
+       // populate sigalgs array just once
        // remove initial default option
        sigalgOption.remove(0); 
        Object.keys(refobj).forEach(function(key) {
@@ -188,11 +197,10 @@ function SubmitHandshakesForm(event) {
     var d = formData.get("date")
     // if toggling between specific date and series, redo chart (e.g., changing type)
     if ((d!="All")||(currentoperations.length!=alloperations.length)||(currentsigalg!=formData.get("sigalg"))) {
-       handshakesChart.destroy();
-       handshakesChart=undefined;
+       LoadData(false, true);
     }
-    LoadData(false);
+    else LoadData(false, false);
     event.preventDefault();
 }
 
-LoadData(true);
+LoadData(true, false);

--- a/visualization/openssl_speed_script.js
+++ b/visualization/openssl_speed_script.js
@@ -42,9 +42,22 @@ function fillNumberTable(tabledata, setDate) {
    }
 }
 
+function CleanSlate() {
+       keygenChart.destroy();
+       keygenChart=undefined;
+       signChart.destroy();
+       signChart=undefined;
+       verifyChart.destroy();
+       verifyChart=undefined;
+       encapChart.destroy();
+       encapChart=undefined;
+       decapChart.destroy();
+       decapChart=undefined;
+}
+
 // main chart-generator function
 // only populate config data if fullInit set to true
-function LoadData(fullInit) {
+function LoadData(fullInit, cleanSlate) {
     var filterForm = document.getElementById('filterForm');
     var formData = new FormData(filterForm);
     var keygendatasets=[];
@@ -55,10 +68,14 @@ function LoadData(fullInit) {
     var dscount=0;
     var charttype = "bar";
 
+    if (cleanSlate) CleanSlate();
+
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false,
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
+    }
+
+    if (refobj == undefined) { // no data yet
+      return;
     }
 
     var setDate = formData.get("date");
@@ -352,22 +369,15 @@ function SubmitOSSLspeedForm(event) {
     var d = formData.get("date")
     // if toggling between specific date and series, redo chart (e.g., changing type)
     if ((d!="All")||(currentoperations.length!=alloperations.length)) {
-       keygenChart.destroy();
-       keygenChart=undefined;
-       signChart.destroy();
-       signChart=undefined;
-       verifyChart.destroy();
-       verifyChart=undefined;
-       encapChart.destroy();
-       encapChart=undefined;
-       decapChart.destroy();
-       decapChart=undefined;
+       LoadData(false, true);
     }
-    LoadData(false);
+    else {
+       LoadData(false, false);
+    }
     event.preventDefault();
 }
 
 
-LoadData(true);
+LoadData(true, false);
 
 

--- a/visualization/speed_kem_script.js
+++ b/visualization/speed_kem_script.js
@@ -42,6 +42,15 @@ function fillNumberTable(tabledata, setDate) {
    }
 }
 
+function CleanSlate() {
+       keygenChart.destroy();
+       keygenChart=undefined;
+       encapChart.destroy();
+       encapChart=undefined;
+       decapChart.destroy();
+       decapChart=undefined;
+}
+
 // called upon any filter change
 function SubmitKEMForm(event) {
     var filterForm = document.getElementById('filterForm');
@@ -52,12 +61,7 @@ function SubmitKEMForm(event) {
     var d = formData.get("date")
     // if toggling between specific date and series, redo chart (e.g., changing type)
     if ((d!="All")||(currentoperations.length!=alloperations.length)) {
-       keygenChart.destroy();
-       keygenChart=undefined;
-       encapChart.destroy();
-       encapChart=undefined;
-       decapChart.destroy();
-       decapChart=undefined;
+       CleanSlate();
     }
     LoadData(false);
     event.preventDefault();
@@ -65,7 +69,7 @@ function SubmitKEMForm(event) {
 
 // main chart-generator function
 // only populate config data if fullInit set to true
-function LoadData(fullInit) {
+function LoadData(fullInit, cleanSlate) {
     var filterForm = document.getElementById('filterForm');
     var formData = new FormData(filterForm);
     var keygendatasets=[];
@@ -74,10 +78,16 @@ function LoadData(fullInit) {
     var dscount=0;
     var charttype = "bar";
 
+    if (cleanSlate) {
+       CleanSlate();
+    }
+
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, 
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
+    }
+
+    if (refobj==undefined) { // no data yet
+       return;
     }
 
     // obtain this only now as loadJSONArray could have changed it:
@@ -260,7 +270,12 @@ function LoadData(fullInit) {
        else {
          if (setDate!="All") {
            var k = keygenChart.data.datasets[i].label;
-           tabledata.push([ k, jsonarray[setDate][k].keygen, jsonarray[setDate][k].keygencycles, jsonarray[setDate][k].encaps, jsonarray[setDate][k].encapscycles, jsonarray[setDate][k].decaps, jsonarray[setDate][k].decapscycles ]);
+           try {
+              tabledata.push([ k, jsonarray[setDate][k].keygen, jsonarray[setDate][k].keygencycles, jsonarray[setDate][k].encaps, jsonarray[setDate][k].encapscycles, jsonarray[setDate][k].decaps, jsonarray[setDate][k].decapscycles ]);
+           }
+           catch (e) { // ref data may not be present
+              tabledata.push([ k, undefined, undefined, undefined, undefined, undefined, undefined ]);
+           }
          }
          keygenChart.data.datasets[i].hidden=false;
          encapChart.data.datasets[i].hidden=false;

--- a/visualization/speed_sig_script.js
+++ b/visualization/speed_sig_script.js
@@ -42,6 +42,15 @@ function fillNumberTable(tabledata, setDate) {
    }
 }
 
+function CleanSlate() {
+       keygenChart.destroy();
+       keygenChart=undefined;
+       signChart.destroy();
+       signChart=undefined;
+       verifyChart.destroy();
+       verifyChart=undefined;
+}
+
 // called upon any filter change
 function SubmitSIGForm(event) {
     var filterForm = document.getElementById('filterForm');
@@ -52,12 +61,7 @@ function SubmitSIGForm(event) {
     var d = formData.get("date")
     // if toggling between specific date and series, redo chart (e.g., changing type)
     if ((d!="All")||(currentoperations.length!=alloperations.length)) {
-       keygenChart.destroy();
-       keygenChart=undefined;
-       signChart.destroy();
-       signChart=undefined;
-       verifyChart.destroy();
-       verifyChart=undefined;
+       CleanSlate();
     }
     LoadData(false);
     event.preventDefault();
@@ -65,7 +69,7 @@ function SubmitSIGForm(event) {
 
 // main chart-generator function
 // only populate config data if fullInit set to true
-function LoadData(fullInit) {
+function LoadData(fullInit, cleanSlate) {
     var filterForm = document.getElementById('filterForm');
     var formData = new FormData(filterForm);
     var keygendatasets=[];
@@ -74,10 +78,16 @@ function LoadData(fullInit) {
     var dscount=0;
     var charttype = "bar";
 
+    if (cleanSlate) {
+       CleanSlate();
+    }
+
     if (jsonarray == undefined) { // loading data just once
-       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, 
-          loadJSONArray(formData, true, undefined)[0] // loading ref data if/when present
-       );
+       [jsonarray, refobj, alloperations] = loadJSONArray(formData, false, undefined);
+    }
+
+    if (refobj==undefined) { // no data yet
+       return;
     }
 
     // obtain this only now as loadJSONArray could have changed it:
@@ -260,7 +270,12 @@ function LoadData(fullInit) {
        else {
          if (setDate!="All") {
            var k = keygenChart.data.datasets[i].label;
-           tabledata.push([ k, jsonarray[setDate][k].keypair, jsonarray[setDate][k].keypaircycles, jsonarray[setDate][k].sign, jsonarray[setDate][k].signcycles, jsonarray[setDate][k].verify, jsonarray[setDate][k].verifycycles ]);
+           try {
+              tabledata.push([ k, jsonarray[setDate][k].keypair, jsonarray[setDate][k].keypaircycles, jsonarray[setDate][k].sign, jsonarray[setDate][k].signcycles, jsonarray[setDate][k].verify, jsonarray[setDate][k].verifycycles ]);
+           }
+           catch (e) { // ref data may not be present
+              tabledata.push([ k, undefined, undefined, undefined, undefined, undefined, undefined ]);
+           }
          }
          keygenChart.data.datasets[i].hidden=false;
          signChart.data.datasets[i].hidden=false;


### PR DESCRIPTION
Another alternative: This one is client-side only (i.e., works with presently created performance data files): This fetches all data asynchronously, displays (only) the first full data set (day) received and then permits selection of other or "All" dates manually: This also speeds up display quite a bit. 

This variant carries the risk that users never notice the option to get the "full data" view (manually selecting "All" dates). 

Again, available for hands-on testing at https://test.openquantumsafe.org/v3/speed_sig_series.html 

@dstebila @xvzcf Please decide which option you like better (or would want to improve upon). I intentionally retained old code for comparison but will delete if OK to move forward with this variant.